### PR TITLE
Link PyPI tutorial to PyPA user guide

### DIFF
--- a/PACKAGING_AND_DEPLOYMENT.md
+++ b/PACKAGING_AND_DEPLOYMENT.md
@@ -33,7 +33,7 @@ While this is changing with wider support for Python wheels (see [PEP 427](https
 #### Distributing your code with PyPI
 
 If you have a pure Python package you would like to upload to PyPI and have already structured it to be installable by a `setup.py` that makes use of [`distutils`](https://docs.python.org/3/library/distutils.html), uploading your package is very easy.
-This [tutorial](http://peterdowns.com/posts/first-time-with-pypi.html) provides a gentle introduction to the whole process, but once everything is structured correctly, uploading is as simple as:
+This [tutorial](https://packaging.python.org/tutorials/packaging-projects/) provides a gentle introduction to the whole process, but once everything is structured correctly, uploading is as simple as:
 ```bash
 python setup.py register -r pypi
 python setup.py sdist upload -r pypi


### PR DESCRIPTION
The existing link to a tutorial on python packaging by Peter Downs is a
broken link. The Python Packaging Authority (PyPA) has an actively
maintained and thorough guide to packaging which I have linked to
as a replacement.